### PR TITLE
🩹 Fixed rounded corners appearing in fullscreen

### DIFF
--- a/bleeding-corners-fix/chrome.css
+++ b/bleeding-corners-fix/chrome.css
@@ -1,3 +1,4 @@
-.browserContainer, .browserStack {
+html:not([sizemode="fullscreen"]) .browserContainer,
+html:not([sizemode="fullscreen"]) .browserStack {
 	clip-path: inset(0 round var(--zen-native-inner-radius));
 }


### PR DESCRIPTION
When entering fullscreen mode with this mod enabled, the corners did not disappear. This PR fixes that issue.

Here's a screenshot of the corner still visible in fullscreen mode:

<img width="31" alt="Screenshot 2025-05-31 at 02 44 25" src="https://github.com/user-attachments/assets/cb395ddd-e3a4-4527-be5a-62db53e4084b" />
